### PR TITLE
Add backend CI pipeline for running async tests in monorepo structure

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -1,0 +1,39 @@
+name: Run Backend API Tests
+
+on:
+  push:
+    paths:
+      - 'backend/**'
+    branches: [main, feature/**]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-backend:
+    runs-on: ubuntu-latest
+
+    env:
+      MONGODB_URI: ${{ secrets.MONGODB_URI }}
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run backend tests
+        run: |
+          pytest app/tests/ --maxfail=1 --disable-warnings -v

--- a/backend/app/services/database.py
+++ b/backend/app/services/database.py
@@ -2,14 +2,17 @@ import os
 from dotenv import load_dotenv
 from motor.motor_asyncio import AsyncIOMotorClient
 
-# Load environment variables
+# Load .env for local dev (ignored in CI/CD)
 load_dotenv()
 
 MONGO_URI = os.getenv("MONGODB_URI")
 
-# Connect to MongoDB Atlas
+if not MONGO_URI:
+    raise ValueError("MONGODB_URI is not set in environment variables.")
+
+# Connect to MongoDB
 client = AsyncIOMotorClient(MONGO_URI)
-db = client["linkedin_post_bot"]  # Database name
+db = client.get_default_database()  # Use DB from URI
 
 # Define collections
 users_collection = db["users"]


### PR DESCRIPTION
### This PR adds a GitHub Actions workflow to run backend tests automatically on every push and pull request.

**Key features:**
- Runs `pytest` on the `backend/app/tests` directory
- Uses `MONGODB_URI` and `JWT_SECRET` from GitHub Secrets
- Runs only when files under `backend/**` are changed
- Uses Python 3.12 (to match local dev environment)
- Installs dependencies from `requirements.txt`
- Supports async tests with Motor and FastAPI

**Purpose:**
To ensure backend tests run reliably and consistently in CI, especially after resolving event loop issues on Windows. This sets the foundation for future automated testing and deployment workflows.
